### PR TITLE
PRODENG-2140 removed the 'mirantis' prefixes of the resources

### DIFF
--- a/mirantis/launchpad/provider.go
+++ b/mirantis/launchpad/provider.go
@@ -7,8 +7,8 @@ import (
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		ResourcesMap: map[string]*schema.Resource{
-			"mirantis-launchpad_launchpad": ResourceConfig(),
-			"mirantis-launchpad_yaml":      ResourceYamlConfig(),
+			"launchpad_config":      ResourceConfig(),
+			"launchpad_yaml_config": ResourceYamlConfig(),
 		},
 	}
 }


### PR DESCRIPTION
# Description

This pr removed the 'mirantis' prefixes of the resources so people using the terraform provider can refer to them by simply:
launchpad_{resource_}
## Issue

https://mirantis.jira.com/browse/PRODENG-2140
