### PR TITLE
PRODENG-2220 Set test chart's provider source to Terraform Cloud

### DIFF
--- a/test/launchpad/main.tf
+++ b/test/launchpad/main.tf
@@ -7,6 +7,7 @@ module "provision" {
   aws_region   = "us-west-2"
   master_count = 1
   worker_count = 3
+  cluster_name = var.cluster_name
 }
 
 // Mirantis installing terraform provider
@@ -21,7 +22,7 @@ resource "launchpad_config" "cluster" {
   }
   spec {
     cluster {
-      prune = false
+      prune = true
     }
 
     dynamic "host" {
@@ -62,21 +63,16 @@ resource "launchpad_config" "cluster" {
       install_url_linux   = "https://get.mirantis.com/"
       install_url_windows = "https://get.mirantis.com/install.ps1"
       repo_url            = "https://repos.mirantis.com"
-      version             = "23.0.3"
+      version             = var.mcr_version
     } // mcr
 
     mke {
-      admin_password = "mirantisadmin"
-      admin_username = "admin"
+      admin_password = var.admin_password
+      admin_username = var.admin_username
       image_repo     = "docker.io/mirantis"
-      version        = "3.6.3"
+      version        = var.mke_version
       install_flags  = ["--san=${module.provision.mke_lb}", "--default-node-orchestrator=kubernetes", "--nodeport-range=32768-35535"]
       upgrade_flags  = ["--force-recent-backup", "--force-minimums"]
     } // mke
-
-  } // spec
+  }   // spec
 }
-
-# output "mke_cluster_name" {
-#   value = launchpad_config.cluster.metadata[0].name
-# }

--- a/test/launchpad/output.tf
+++ b/test/launchpad/output.tf
@@ -7,3 +7,7 @@ output "mke_lb" {
   value       = "https://${module.provision.mke_lb}"
   description = "LB path for the MKE ingress"
 }
+
+output "mke_cluster_name" {
+  value = launchpad_config.cluster.metadata[0].name
+}

--- a/test/launchpad/variables.tf
+++ b/test/launchpad/variables.tf
@@ -1,5 +1,5 @@
 variable "cluster_name" {
-  default = "tf-mcc-provider-test"
+  default = "mcc-test"
 }
 
 variable "aws_region" {
@@ -14,7 +14,7 @@ variable "admin_username" {
   default = "admin"
 }
 variable "admin_password" {
-  default = "tum40PJ9lGIFySvPeNQYsUBGz8zIKlia"
+  default = "mirantisorca"
 }
 
 variable "keypath" {
@@ -61,7 +61,6 @@ variable "worker_volume_size" {
 variable "msr_volume_size" {
   default = 100
 }
-
 
 variable "mcr_version" {
   type        = string

--- a/test/launchpad/versions.tf
+++ b/test/launchpad/versions.tf
@@ -3,8 +3,7 @@ terraform {
   required_version = ">= 1.0.0"
   required_providers {
     launchpad = {
-      version = "0.9.0"
-      source  = "mirantis.com/providers/mirantis-launchpad"
+      source = "Mirantis/launchpad"
     }
     mirantis-msr-connect = {
       source = "Mirantis/msr"


### PR DESCRIPTION
# Description

Set test chart's launchpad provider source to Terraform Cloud

## Issue

https://mirantis.jira.com/browse/PRODENG-2220
