### PR TITLE
PRODENG-2275 Pinned golang version in github action to 1.20

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.20
+        go-version: '1.20'
     - name: Setup MCC gitub repo private access
       run: git config --global url."https://$GH_USERNAME:$GH_ACCESS_TOKEN@github.com/".insteadOf "https://github.com/"
 


### PR DESCRIPTION
# Description

The go github action support Golang Version 1.20 or less

## Issue

https://mirantis.jira.com/browse/PRODENG-2275
