### PR TITLE
Add mcrConfig to the schema

### DIFF
--- a/internal/provider/mcc_schema_1_4.go
+++ b/internal/provider/mcc_schema_1_4.go
@@ -256,6 +256,50 @@ func launchpadSchema14() schema.Schema {
 									},
 								},
 
+								"mcrConfig": schema.ListNestedBlock{
+									MarkdownDescription: "MCR configuration for the host",
+
+									Validators: []validator.List{
+										listvalidator.SizeAtMost(1),
+									},
+
+									NestedObject: schema.NestedBlockObject{
+										Attributes: map[string]schema.Attribute{
+											"debug": schema.BoolAttribute{
+												MarkdownDescription: "Log level",
+												Default:             booldefault.StaticBool(false),
+												Optional:            true,
+											},
+											"bip": schema.StringAttribute{
+												MarkdownDescription: "Base IP",
+												Optional:            true,
+											},
+										},
+										Blocks: map[string]schema.Block{
+
+											"default-address-pool": schema.ListNestedBlock{
+												MarkdownDescription: "Reassign docker subnets",
+
+												NestedObject: schema.NestedBlockObject{
+													Attributes: map[string]schema.Attribute{
+														"base": schema.StringAttribute{
+															MarkdownDescription: "The CIDR range allocated for bridge networks in each IP address pool.",
+															Optional:            true,
+															Computed:            true,
+														},
+														"size": schema.Int64Attribute{
+															MarkdownDescription: "The CIDR netmask that determines the subnet size to allocate from the base pool.",
+															Default:             int64default.StaticInt64(16),
+															Optional:            true,
+															Computed:            true,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+
 								"ssh": schema.ListNestedBlock{
 									MarkdownDescription: "SSH configuration for the host",
 
@@ -428,6 +472,8 @@ func (ls launchpadSchema14Model) ClusterConfig(diags diag.Diagnostics) (mcc_mke_
 		mccHost := mcc_mke_api.Host{
 			Role:  host.Role.ValueString(),
 			Hooks: mcc_common_api.Hooks{},
+			// TODO: Fix line below
+			// DaemonConfig: &mcc_common_api.MCRConfig{},
 		}
 
 		if len(host.SSH) > 0 {
@@ -455,6 +501,8 @@ func (ls launchpadSchema14Model) ClusterConfig(diags diag.Diagnostics) (mcc_mke_
 				},
 			}
 		}
+
+		// TODO: Add some logic for MCR config
 
 		if len(host.Hooks) > 0 {
 			sh := host.Hooks[0]
@@ -529,13 +577,23 @@ type launchpadSchema14ModelSpecMSR struct {
 }
 
 type launchpadSchema14ModelSpecHost struct {
-	Role  types.String                          `tfsdk:"role"`
-	Hooks []launchpadSchema14ModelSpecHostHooks `tfsdk:"hooks"`
-	SSH   []launchpadSchema14ModelSpecHostSSH   `tfsdk:"ssh"`
-	WinRM []launchpadSchema14ModelSpecHostWinrm `tfsdk:"winrm"`
+	Role      types.String                              `tfsdk:"role"`
+	Hooks     []launchpadSchema14ModelSpecHostHooks     `tfsdk:"hooks"`
+	SSH       []launchpadSchema14ModelSpecHostSSH       `tfsdk:"ssh"`
+	WinRM     []launchpadSchema14ModelSpecHostWinrm     `tfsdk:"winrm"`
+	MCRConfig []launchpadSchema14ModelSpecHostMCRconfig `tfsdk:"mcrconfig"`
 }
 type launchpadSchema14ModelSpecHostHooks struct {
 	Apply []launchpadSchema14ModelSpecHostHookAction `tfsdk:"apply"`
+}
+type launchpadSchema14ModelSpecHostMCRconfig struct {
+	Debug              types.Bool
+	Bip                types.String
+	DefaultAddressPool []launchpadSchema14ModelSpecHostMCRconfigDefaultAddressPool `tfsdk:"defaultaddresspool"`
+}
+type launchpadSchema14ModelSpecHostMCRconfigDefaultAddressPool struct {
+	Base types.String `tfsdk:"base"`
+	Size types.Int64  `tfsdk:"size"`
 }
 type launchpadSchema14ModelSpecHostHookAction struct {
 	Before types.List `tfsdk:"before"`


### PR DESCRIPTION
# Description

Adding `mcrConfig` to provider's schema according to documentation. An example:

```yaml
spec:
    mcrConfig:
      debug: true
      bip: "172.20.0.1/16"
      default-address-pool:
      - base: "172.20.0.0/16"
        size: 16
```

I haven't added those fields yet (but they are present in the documentation) because they're not really important in our case, but I think they need to be added:

```yaml
spec:
  mcrConfig:
    log-opts:
      max-size: 10m
      max-file: "3"
```
 

