### PR TITLE
PRODENG-2281 fix mcrconfig value parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,15 @@ No requirements.
 
 ## Providers
 
+No providers.
+
 ## Modules
 
+No modules.
+
 ## Resources
+
+No resources.
 
 ## Inputs
 

--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -163,14 +163,17 @@ Optional:
 
 - `bip` (String) Base IP
 - `debug` (Boolean) Log level
-- `default_address_pool` (Block List) Reassign docker subnets (see [below for nested schema](#nestedblock--spec--host--mcr_config--default_address_pool))
+- `default_address_pool` (Attributes List) Reassign docker subnets (see [below for nested schema](#nestedatt--spec--host--mcr_config--default_address_pool))
 
-<a id="nestedblock--spec--host--mcr_config--default_address_pool"></a>
+<a id="nestedatt--spec--host--mcr_config--default_address_pool"></a>
 ### Nested Schema for `spec.host.mcr_config.default_address_pool`
+
+Required:
+
+- `base` (String) The CIDR range allocated for bridge networks in each IP address pool.
 
 Optional:
 
-- `base` (String) The CIDR range allocated for bridge networks in each IP address pool.
 - `size` (Number) The CIDR netmask that determines the subnet size to allocate from the base pool.
 
 

--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -163,10 +163,10 @@ Optional:
 
 - `bip` (String) Base IP
 - `debug` (Boolean) Log level
-- `default_address_pool` (Attributes List) Reassign docker subnets (see [below for nested schema](#nestedatt--spec--host--mcr_config--default_address_pool))
+- `default_address_pools` (Attributes List) Reassign docker subnets (see [below for nested schema](#nestedatt--spec--host--mcr_config--default_address_pools))
 
-<a id="nestedatt--spec--host--mcr_config--default_address_pool"></a>
-### Nested Schema for `spec.host.mcr_config.default_address_pool`
+<a id="nestedatt--spec--host--mcr_config--default_address_pools"></a>
+### Nested Schema for `spec.host.mcr_config.default_address_pools`
 
 Required:
 

--- a/internal/provider/launchpad_config_resource.go
+++ b/internal/provider/launchpad_config_resource.go
@@ -60,13 +60,12 @@ func (r *LaunchpadConfigResource) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	cc, err := cls.ClusterConfig(resp.Diagnostics)
-	if err != nil {
+	cc := cls.ClusterConfig(&resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		resp.Diagnostics.AddError(
 			"Failed to build cluster config from terraform config",
-			err.Error(),
+			"Provider failed to convert resource schema to a usable cluster config",
 		)
-
 		return
 	}
 
@@ -132,13 +131,12 @@ func (r *LaunchpadConfigResource) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	cc, err := cls.ClusterConfig(resp.Diagnostics)
-	if err != nil {
+	cc := cls.ClusterConfig(&resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		resp.Diagnostics.AddError(
 			"Failed to build cluster config from terraform config",
-			err.Error(),
+			"Provider failed to convert resource schema to a usable cluster config",
 		)
-
 		return
 	}
 
@@ -190,13 +188,12 @@ func (r *LaunchpadConfigResource) Delete(ctx context.Context, req resource.Delet
 		return
 	}
 
-	cc, err := sls.ClusterConfig(resp.Diagnostics)
-	if err != nil {
+	cc := sls.ClusterConfig(&resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
 		resp.Diagnostics.AddError(
 			"Failed to build cluster config from terraform config",
-			err.Error(),
+			"Provider failed to convert resource schema to a usable cluster config",
 		)
-
 		return
 	}
 

--- a/internal/provider/launchpad_config_resource_test.go
+++ b/internal/provider/launchpad_config_resource_test.go
@@ -60,10 +60,17 @@ resource "launchpad_config" "test" {
                 debug = true
                 bip = "172.20.0.1/16"
 
-                default_address_pool {
-                    base = "172.20.0.0/16"
-                    size = 16
-                }
+                default_address_pool = [
+                    {
+                        base="172.21.0.0",
+                        size=16
+                        test="test" // this should produce an error but it doesn't
+                    },
+                    {
+                        base="172.22.0.0",
+                        size=16
+                    }
+                ]
             }
         }
 

--- a/internal/provider/mcc_schema_1_4.go
+++ b/internal/provider/mcc_schema_1_4.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
@@ -290,23 +289,25 @@ func launchpadSchema14() schema.Schema {
 												Computed:            true,
 												Default:             stringdefault.StaticString(""),
 											},
-										},
-										Blocks: map[string]schema.Block{
 
-											"default_address_pool": schema.ListNestedBlock{
+											"default_address_pool": schema.ListNestedAttribute{
 												MarkdownDescription: "Reassign docker subnets",
 
-												Validators: []validator.List{
-													listvalidator.SizeAtMost(1),
-												},
+												Optional: true,
 
-												NestedObject: schema.NestedBlockObject{
+												NestedObject: schema.NestedAttributeObject{
+
+													Validators: []validator.Object{
+														// @todo validate that only base and size attributes were added
+														// because in our unit test I was able to add fields that
+														// did not exist.
+														// @see: "github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
+													},
+
 													Attributes: map[string]schema.Attribute{
 														"base": schema.StringAttribute{
 															MarkdownDescription: "The CIDR range allocated for bridge networks in each IP address pool.",
-															Optional:            true,
-															Computed:            true,
-															Default:             stringdefault.StaticString(""),
+															Required:            true,
 														},
 														"size": schema.Int64Attribute{
 															MarkdownDescription: "The CIDR netmask that determines the subnet size to allocate from the base pool.",
@@ -408,7 +409,7 @@ func (ls launchpadSchema14Model) ClusterEqual(c launchpadSchema14Model) bool {
 }
 
 // ClusterConfig convert this state object into a proper ClusterConfig.
-func (ls launchpadSchema14Model) ClusterConfig(diags diag.Diagnostics) (mcc_mke_api.ClusterConfig, error) {
+func (ls launchpadSchema14Model) ClusterConfig(diags *diag.Diagnostics) mcc_mke_api.ClusterConfig {
 	cc := mcc_mke_api.ClusterConfig{
 		APIVersion: "launchpad.mirantis.com/mke/v1.4",
 		Kind:       "mke",
@@ -540,9 +541,20 @@ func (ls launchpadSchema14Model) ClusterConfig(diags diag.Diagnostics) (mcc_mke_
 			 *
 			 */
 
-			daemonConfig["debug"] = mcrConfig.Debug
-			daemonConfig["bip"] = mcrConfig.Bip
-			daemonConfig["default-address-pool"] = mcrConfig.DefaultAddressPool
+			daemonConfig["debug"] = mcrConfig.Debug.ValueBool()
+			daemonConfig["bip"] = mcrConfig.Bip.ValueString()
+
+			if len(mcrConfig.DefaultAddressPool) > 0 {
+				daps := []interface{}{}
+				for _, dap := range mcrConfig.DefaultAddressPool {
+					dapm := map[string]interface{}{
+						"base": dap.Base.ValueString(),
+						"size": dap.Size.ValueInt64(),
+					}
+					daps = append(daps, dapm)
+				}
+				daemonConfig["default-address-pool"] = daps
+			}
 
 			mccHost.DaemonConfig = daemonConfig
 		}
@@ -574,7 +586,7 @@ func (ls launchpadSchema14Model) ClusterConfig(diags diag.Diagnostics) (mcc_mke_
 		cc.Spec.Hosts = append(cc.Spec.Hosts, &mccHost)
 	}
 
-	return cc, nil
+	return cc
 }
 
 type launchpadSchema14ModelMetadata struct {

--- a/internal/provider/mcc_schema_1_4.go
+++ b/internal/provider/mcc_schema_1_4.go
@@ -290,7 +290,7 @@ func launchpadSchema14() schema.Schema {
 												Default:             stringdefault.StaticString(""),
 											},
 
-											"default_address_pool": schema.ListNestedAttribute{
+											"default_address_pools": schema.ListNestedAttribute{
 												MarkdownDescription: "Reassign docker subnets",
 
 												Optional: true,
@@ -544,16 +544,16 @@ func (ls launchpadSchema14Model) ClusterConfig(diags *diag.Diagnostics) mcc_mke_
 			daemonConfig["debug"] = mcrConfig.Debug.ValueBool()
 			daemonConfig["bip"] = mcrConfig.Bip.ValueString()
 
-			if len(mcrConfig.DefaultAddressPool) > 0 {
+			if len(mcrConfig.DefaultAddressPools) > 0 {
 				daps := []interface{}{}
-				for _, dap := range mcrConfig.DefaultAddressPool {
+				for _, dap := range mcrConfig.DefaultAddressPools {
 					dapm := map[string]interface{}{
 						"base": dap.Base.ValueString(),
 						"size": dap.Size.ValueInt64(),
 					}
 					daps = append(daps, dapm)
 				}
-				daemonConfig["default-address-pool"] = daps
+				daemonConfig["default-address-pools"] = daps
 			}
 
 			mccHost.DaemonConfig = daemonConfig
@@ -642,11 +642,11 @@ type launchpadSchema14ModelSpecHostHooks struct {
 	Apply []launchpadSchema14ModelSpecHostHookAction `tfsdk:"apply"`
 }
 type launchpadSchema14ModelSpecHostMCRconfig struct {
-	Debug              types.Bool                                                  `json:"debug" tfsdk:"debug"`
-	Bip                types.String                                                `json:"bip" tfsdk:"bip"`
-	DefaultAddressPool []launchpadSchema14ModelSpecHostMCRconfigDefaultAddressPool `json:"default-address-pool" tfsdk:"default_address_pool"`
+	Debug               types.Bool                                                   `json:"debug" tfsdk:"debug"`
+	Bip                 types.String                                                 `json:"bip" tfsdk:"bip"`
+	DefaultAddressPools []launchpadSchema14ModelSpecHostMCRconfigDefaultAddressPools `json:"default-address-pools" tfsdk:"default_address_pools"`
 }
-type launchpadSchema14ModelSpecHostMCRconfigDefaultAddressPool struct {
+type launchpadSchema14ModelSpecHostMCRconfigDefaultAddressPools struct {
 	Base types.String `json:"base" tfsdk:"base"`
 	Size types.Int64  `json:"size" tfsdk:"size"`
 }


### PR DESCRIPTION
# Description

- existing parsing was not properly building cluster config
- switch to nested attribute instead of nested blocks

Also

- schema transform was supposed to return errors but it never
  did, so that is removed in favour of adding diags

## Issue

https://mirantis.jira.com/browse/PRODENG-2281
