### PR TITLE
PRODENG-2286 rewrite provider to fix operations

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,46 +2,22 @@ default: test
 
 LOCAL_TAG=$(shell git describe --tags)
 
-# Run local unit testr
-.PHONY: test
-test:
-	go test ./... -timeout 120ms
+GOOS=$(shell go env GOOS)
+GOARCH=$(shell go env .GOARCH)
 
-# Run acceptance tests
+# Run local unit tests (which use the acceptance test suite)
+# @NOTE these are run with the provider/resources in testing mode
 .PHONY: testacc
 testacc:
-	TF_ACC=1 go test ./... -v $(TESTARGS) -tags=integration -timeout 120m
+	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m
+
+# Lint by running golangci-lint in a docker container
+.PHONY: lint
+lint:
+	docker run -ti --rm -v "$(CURDIR):/data" -w "/data" golangci/golangci-lint:latest golangci-lint run
 
 # Local install of the plugin
 .PHONY: local
 local:
 	GORELEASER_CURRENT_TAG="$(LOCAL_TAG)" goreleaser build --clean --single-target --skip-validate
-
-	# "Local plugin generated. Use $(CURDIR)/dist/terraform-provider-launchpad_linux_amd64_v1 as your dev_overrides path in a terraform config file
-	#
-	# my_tf_config_file:
-	# ```
-	# provider_installation {
-	#
-	#	# This disables the version and checksum verifications for this provider
-	#	# and forces Terraform to look for the launchpad provider plugin in the
-	#	# given directory.
-	#	dev_overrides {
-	#		"mirantis/launchpad" = "$(CURDIR)/dist/terraform-provider-launchpad_linux_amd64_v1"
-	#	}
-	#
-	#	# For all other providers, install them directly from their origin provider
-	#	# registries as normal. If you omit this, Terraform will _only_ use
-	#	# the dev_overrides block, and so no other providers will be available.
-	#	direct {}
-	# }
-	# ```
-	#
-	# then run terraform with a config file override:
-	# ```
-	#  $/> TF_CLI_CONFIG_FILE=my_tf_config_file terraform plan
-	# ```
-	# (or use an export)
-	#
-	# @see: https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers"
-	#
+	# @SEE README.md on how to use the locally built plugin

--- a/README.md
+++ b/README.md
@@ -60,6 +60,52 @@ provider locally,
 
 ## Developing the Provider
 
+### Using the local provider
+
+You can develop the provider locally, and test the development version by building
+the plugin locally, and then configuring terraform to use the local version as a
+`dev_override` for the production version.
+
+To build the local plugin:
+```
+make local
+```
+
+It is recommended that you use the `dev_override` by using a special TF config file
+and running terraform with an environment variable telling it to use the special file.
+This avoids using the development version globally, preventing simple mistakes.
+
+First create a file like my_tf_config_file:
+
+```
+provider_installation {
+# This disables the version and checksum verifications for this provider
+# and forces Terraform to look for the launchpad provider plugin in the
+# given directory.
+dev_overrides {
+	"mirantis/launchpad" = "path/to/this/repo/dist/terraform-provider-launchpad_linux_amd64_v1"
+}
+# For all other providers, install them directly from their origin provider
+# registries as normal. If you omit this, Terraform will _only_ use
+# the dev_overrides block, and so no other providers will be available.
+direct {}
+}
+```
+
+@NOTE that you mus replace `linux` and `amd64` if you are on a Mac/Windows machine
+  or not on a 64bit intel/amd processor.  See `go env GOOS` and `go env GOARCH` for
+  the correct values.
+
+then run terraform with a config file override pointing to the new file:
+```
+ $/> TF_CLI_CONFIG_FILE=my_tf_config_file terraform plan
+```
+(or use an environment variable export)
+
+@see: https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers"
+
+### Contributing
+
 To generate or update documentation, run `go generate`.
 
 In order to run the testing mode unit test suite:

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	github.com/Mirantis/mcc v0.0.0-20221202073622-0780228511dd
+	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/k0sproject/dig v0.2.0
 	github.com/k0sproject/rig v0.10.0
 	github.com/sirupsen/logrus v1.9.0
@@ -60,7 +61,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.18.1 // indirect
 	github.com/hashicorp/terraform-json v0.16.0 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.1 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect

--- a/internal/provider/launchpad_config_resource.go
+++ b/internal/provider/launchpad_config_resource.go
@@ -1,15 +1,15 @@
 package provider
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"gopkg.in/yaml.v2"
 
 	mcc_mke "github.com/Mirantis/mcc/pkg/product/mke"
-	mcc_logrus "github.com/sirupsen/logrus"
 )
 
 var _ resource.Resource = &LaunchpadConfigResource{}
@@ -51,53 +51,28 @@ func (r *LaunchpadConfigResource) Configure(ctx context.Context, req resource.Co
 }
 
 func (r *LaunchpadConfigResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var cls *launchpadSchema14Model
-
-	// Read Terraform plan data into the model
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &cls)...)
+	model, mke := getterToModelAndProduct(ctx, &resp.Diagnostics, req.Plan.Get, false)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	cc := cls.ClusterConfig(&resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		resp.Diagnostics.AddError(
-			"Failed to build cluster config from terraform config",
-			"Provider failed to convert resource schema to a usable cluster config",
-		)
-		return
-	}
-
-	c := mcc_mke.MKE{ClusterConfig: cc}
-
-	if err := cc.Validate(); err != nil {
-		resp.Diagnostics.AddError(
-			"Launchpad config validation failed",
-			err.Error(),
-		)
-
-		return
-	}
-
-	logrusBuffer := &bytes.Buffer{}
-	mcc_logrus.SetOutput(logrusBuffer)
 
 	if r.testingMode {
 		resp.Diagnostics.AddWarning("testing mode warning", "launchpad config resource handler is in testing mode, no installation will be run.")
-	} else if err := c.Apply(false, false, 10); err != nil {
-		ccout, _ := yaml.Marshal(cc)
+
+	} else if err := mke.Apply(false, false, 10); err != nil {
+		ccout, _ := yaml.Marshal(mke.ClusterConfig)
 		resp.Diagnostics.AddError(
 			"Launchpad apply failed",
-			fmt.Sprintf("%s \n\n%s; %s", ccout, err.Error(), logrusBuffer.String()),
+			fmt.Sprintf("config: %s \n\n%s", ccout, err.Error()),
 		)
 
 		return
 	}
 
-	cls.Id = cls.Metadata.Name
+	model.Id = model.Metadata.Name
 
-	if diags := resp.State.Set(ctx, cls); diags != nil {
+	if diags := resp.State.Set(ctx, model); diags != nil {
 		resp.Diagnostics.Append(diags...)
 	}
 }
@@ -107,107 +82,44 @@ func (r *LaunchpadConfigResource) Read(ctx context.Context, req resource.ReadReq
 }
 
 func (r *LaunchpadConfigResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// if enough attributes have changed then run apply
-	var cls launchpadSchema14Model
-	var sls launchpadSchema14Model
-
-	if diags := req.Config.Get(ctx, &cls); diags != nil {
-		resp.Diagnostics.Append(diags...)
-	}
-	if diags := req.State.Get(ctx, &sls); diags != nil {
-		resp.Diagnostics.Append(diags...)
-	}
+	model, mke := getterToModelAndProduct(ctx, &resp.Diagnostics, req.Plan.Get, false)
 
 	if resp.Diagnostics.HasError() {
-		resp.Diagnostics.AddError(
-			"Launchpad config interpret failed",
-			"Failed to interpret either the resource config or state",
-		)
-
 		return
 	}
-
-	if cls.ClusterEqual(sls) {
-		return
-	}
-
-	cc := cls.ClusterConfig(&resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		resp.Diagnostics.AddError(
-			"Failed to build cluster config from terraform config",
-			"Provider failed to convert resource schema to a usable cluster config",
-		)
-		return
-	}
-
-	c := mcc_mke.MKE{ClusterConfig: cc}
-
-	if err := cc.Validate(); err != nil {
-		resp.Diagnostics.AddError(
-			"Launchpad config validation failed",
-			err.Error(),
-		)
-
-		return
-	}
-
-	logrusBuffer := &bytes.Buffer{}
-	mcc_logrus.SetOutput(logrusBuffer)
 
 	if r.testingMode {
 		resp.Diagnostics.AddWarning("testing mode warning", "launchpad config resource handler is in testing mode, no update will be run.")
-	} else if err := c.Apply(false, false, 10); err != nil {
+
+	} else if err := mke.Apply(false, false, 10); err != nil {
+		ccout, _ := yaml.Marshal(mke.ClusterConfig)
 		resp.Diagnostics.AddError(
 			"Launchpad apply failed",
-			fmt.Sprintf("%s; %s", err.Error(), logrusBuffer.String()),
+			fmt.Sprintf("config: %s \n\n%s", ccout, err.Error()),
 		)
 
 		return
 	}
 
-	if diags := resp.State.Set(ctx, cls); diags != nil {
+	if diags := resp.State.Set(ctx, model); diags != nil {
 		resp.Diagnostics.Append(diags...)
 	}
 }
 
 func (r *LaunchpadConfigResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var sls launchpadSchema14Model
+	_, mke := getterToModelAndProduct(ctx, &resp.Diagnostics, req.State.Get, false)
 
-	diags := req.State.Get(ctx, &sls)
-	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	if sls.SkipDestroy.ValueBool() {
-		resp.Diagnostics.AddWarning(
-			"Cluster destruction was skipped!",
-			"The cluster was not actively destroyed, as configuration told us to skip destruction",
-		)
-
-		return
-	}
-
-	cc := sls.ClusterConfig(&resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		resp.Diagnostics.AddError(
-			"Failed to build cluster config from terraform config",
-			"Provider failed to convert resource schema to a usable cluster config",
-		)
-		return
-	}
-
-	c := mcc_mke.MKE{ClusterConfig: cc}
-
-	logrusBuffer := &bytes.Buffer{}
-	mcc_logrus.SetOutput(logrusBuffer)
 
 	if r.testingMode {
 		resp.Diagnostics.AddWarning("testing mode warning", "launchpad config resource handler is in testing mode, no reset will be run.")
-	} else if err := c.Reset(); err != nil {
+
+	} else if err := mke.Reset(); err != nil {
 		resp.Diagnostics.AddError(
 			"Launchpad Reset failed",
-			fmt.Sprintf("%s; %s", err.Error(), logrusBuffer.String()),
+			fmt.Sprintf("error: %s", err.Error()),
 		)
 
 		return
@@ -218,5 +130,46 @@ func (r *LaunchpadConfigResource) Delete(ctx context.Context, req resource.Delet
 }
 
 func (r *LaunchpadConfigResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// an import is an invalid operation for launchpad, as it will want to run anyway. Just add the resource and apply it.
+	resp.Diagnostics.AddError("Launchpad imports are invalid", "The launchpad resource does not support imports, as launchpad itself doesn't maintain state. Just add the resource and hit apply.a")
+}
 
+// Get the schema model (for state) and create an MKE Product object from a getter such as a req.State.Get or req.Plan.Get or req.Config.Get
+// this is a helper for frequently repeated code where we want to interpret schema into a model to add to state, and an MKE Product to take action against.
+func getterToModelAndProduct(ctx context.Context, diags *diag.Diagnostics, getter func(context.Context, interface{}) diag.Diagnostics, skipValidation bool) (launchpadSchema14Model, mcc_mke.MKE) {
+	var ls launchpadSchema14Model
+	var mke mcc_mke.MKE
+
+	// Read Terraform plan data into the model
+	getDiags := getter(ctx, &ls)
+	diags.Append(getDiags...) // this could be one-lined, but this easier to read
+
+	if diags.HasError() {
+		return ls, mke
+	}
+
+	cc := ls.ClusterConfig(diags)
+
+	// Capture the resulting cluster config as yaml to help debugging
+	if b, err := yaml.Marshal(cc); err == nil {
+		tflog.Info(ctx, "ClusterConfig created", map[string]interface{}{"cc": string(b)})
+	} else {
+		// this is weird
+		tflog.Warn(ctx, "ClusterConfig yaml Marshal failed", map[string]interface{}{"err": err})
+	}
+
+	mke = mcc_mke.MKE{ClusterConfig: cc}
+
+	if !skipValidation {
+		tflog.Debug(ctx, "running validation of created mcc.mke.clusterconfig", map[string]interface{}{})
+
+		if err := mke.ClusterConfig.Validate(); err != nil {
+			diags.AddError(
+				"Launchpad config validation failed",
+				err.Error(),
+			)
+		}
+	}
+
+	return ls, mke
 }

--- a/internal/provider/launchpad_config_resource_test.go
+++ b/internal/provider/launchpad_config_resource_test.go
@@ -39,7 +39,7 @@ resource "launchpad_config" "test" {
             install_flags  = ["--flag1", "--flag2" ]
         }
         msr {
-            version = "2.9.4"
+            version = "2.9.1"
         }
 
         host {
@@ -60,7 +60,7 @@ resource "launchpad_config" "test" {
                 debug = true
                 bip = "172.20.0.1/16"
 
-                default_address_pool = [
+                default_address_pools = [
                     {
                         base="172.21.0.0",
                         size=16

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,13 +2,11 @@ package provider
 
 import (
 	"context"
-	//	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	//	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 const (
@@ -57,6 +55,8 @@ func (p *LaunchpadProvider) Configure(ctx context.Context, req provider.Configur
 
 	resp.ResourceData = &data
 	resp.DataSourceData = &data
+
+	AllLoggingToTFLog()
 }
 
 func (p *LaunchpadProvider) Resources(ctx context.Context) []func() resource.Resource {

--- a/internal/provider/tools.go
+++ b/internal/provider/tools.go
@@ -1,0 +1,99 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/k0sproject/rig"
+	"github.com/sirupsen/logrus"
+)
+
+// AllLoggingToTFLog turns on passing of ruslog and log to tflog.
+func AllLoggingToTFLog() {
+	logrus.AddHook(logrusTFLogHandler{})
+	rig.SetLogger(rigTFLogLogger{})
+
+	logrus.SetOutput(io.Discard)
+	log.SetOutput(io.Discard) // we should probably catch base log errors.
+}
+
+// logRusTFLogHandler a tflog handler which integrates logrus so that logrus output gets handled natively.
+type logrusTFLogHandler struct{}
+
+// Fire off a logrus event.
+func (lh logrusTFLogHandler) Fire(e *logrus.Entry) error {
+	go func(event *logrus.Entry) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+		logrusTFLogFire(ctx, event)
+	}(e)
+
+	return nil
+}
+
+// Levels that this logrus hook will handle.
+func (lh logrusTFLogHandler) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func logrusTFLogFire(ctx context.Context, e *logrus.Entry) {
+	mes := e.Message
+	addFields := map[string]interface{}{}
+
+	switch e.Level {
+	case logrus.DebugLevel:
+		tflog.Debug(ctx, mes, addFields)
+	case logrus.ErrorLevel, logrus.PanicLevel, logrus.FatalLevel:
+		tflog.Error(ctx, mes, addFields)
+	case logrus.InfoLevel:
+		tflog.Info(ctx, mes, addFields)
+	case logrus.WarnLevel:
+		tflog.Warn(ctx, mes, addFields)
+	}
+}
+
+// rigTFLogLogger Logger that converts k0sProject logging to tflog.
+type rigTFLogLogger struct {
+}
+
+func (l rigTFLogLogger) Tracef(msg string, values ...interface{}) {
+	rigLoggerTFLogFire(logrus.TraceLevel, msg, values...)
+}
+func (l rigTFLogLogger) Debugf(msg string, values ...interface{}) {
+	rigLoggerTFLogFire(logrus.DebugLevel, msg, values...)
+}
+func (l rigTFLogLogger) Infof(msg string, values ...interface{}) {
+	rigLoggerTFLogFire(logrus.InfoLevel, msg, values...)
+}
+func (l rigTFLogLogger) Warnf(msg string, values ...interface{}) {
+	rigLoggerTFLogFire(logrus.WarnLevel, msg, values...)
+}
+func (l rigTFLogLogger) Errorf(msg string, values ...interface{}) {
+	rigLoggerTFLogFire(logrus.ErrorLevel, msg, values...)
+}
+
+// rigLoggerTFLogFire Take a k0sProject.Rig log entry, and fire a tflog entry.
+func rigLoggerTFLogFire(level logrus.Level, entry string, values ...interface{}) {
+	go func(msg string) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+		defer cancel()
+
+		addFields := map[string]interface{}{}
+
+		switch level {
+		case logrus.DebugLevel:
+			tflog.Debug(ctx, msg, addFields)
+		case logrus.ErrorLevel, logrus.PanicLevel, logrus.FatalLevel:
+			tflog.Error(ctx, msg, addFields)
+		case logrus.InfoLevel:
+			tflog.Info(ctx, msg, addFields)
+		case logrus.WarnLevel:
+			tflog.Warn(ctx, msg, addFields)
+		}
+
+	}(fmt.Sprintf(entry, values...))
+}


### PR DESCRIPTION
# Description

ReWrite the action methods for the launchpad config resource, as some were failing on updates
with id and value errors.
The ReWrite improved a lot of code, but it looks like the issue was primarily that the update function
was building from config, instead of from the plan. The config object doesn't have the id from state.

- launchpad resource methods use single function for interpreting and validating schema (dedupe)
- centralized logrus logging into a tflog handler
- cleaned up some parsing to prevent mrs hosts without msr config (which produces a panic) 
  (this is better done in a validator, but I haven't had time to write one)

## Issue

https://mirantis.jira.com/browse/PRODENG-2286