### PR TITLE
PRODENG-2320 added mke config and cloud

### DIFF
--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -235,10 +235,26 @@ Required:
 Optional:
 
 - `admin_username` (String) MKE admin user name
+- `cloud` (Block List) Cloud Provider configuration (see [below for nested schema](#nestedblock--spec--mke--cloud))
+- `config_data` (String) Inline toml config data
+- `config_file` (String) Path to toml config file
 - `image_repo` (String) Image repo for MKE images
 - `install_flags` (List of String) Optional MKE bootstrapper install flags
 - `license_file_path` (String) MKE license file path
 - `upgrade_flags` (List of String) Optional MKE bootstrapper update flags
+
+<a id="nestedblock--spec--mke--cloud"></a>
+### Nested Schema for `spec.mke.cloud`
+
+Required:
+
+- `provider` (String) Cloud Provider plugin to use
+
+Optional:
+
+- `config_data` (String) Cloud provider inline configuration
+- `config_file` (String) Cloud provider config file path
+
 
 
 <a id="nestedblock--spec--msr"></a>

--- a/internal/provider/launchpad_config_resource_test.go
+++ b/internal/provider/launchpad_config_resource_test.go
@@ -15,8 +15,12 @@ func TestAccLaunchpadConfigResource(t *testing.T) {
 			{
 				Config: testAccLaunchpadConfigResourceConfig_minimal(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("launchpad_config.test", "skip_destroy", "false"),
+					resource.TestCheckResourceAttr("launchpad_config.test", "skip_destroy", "true"),
 					resource.TestCheckResourceAttr("launchpad_config.test", "spec.host.0.hooks.0.apply.0.before.0", "ls -la"),
+					resource.TestCheckResourceAttr("launchpad_config.test", "spec.mcr.version", "23.06"),
+					resource.TestCheckResourceAttr("launchpad_config.test", "spec.mke.install_flags.1", "--flag2"),
+					resource.TestCheckResourceAttr("launchpad_config.test", "spec.mke.config_data", "[sometoml]"),
+					resource.TestCheckResourceAttr("launchpad_config.test", "spec.mke.cloud.0.config_data", "someconfig"),
 				),
 			},
 		},
@@ -26,17 +30,26 @@ func TestAccLaunchpadConfigResource(t *testing.T) {
 func testAccLaunchpadConfigResourceConfig_minimal() string {
 	return `
 resource "launchpad_config" "test" {
+    skip_destroy = true
+
     metadata {
         name = "test"
     }
     spec {
         mcr {
-            version = "22.10"
+            version = "23.06"
         }
         mke {
             version        = "3.6.4"
             admin_password = "mypassword"
             install_flags  = ["--flag1", "--flag2" ]
+
+            config_data    = "[sometoml]"
+
+            cloud {
+                provider    = "aws"
+                config_data = "someconfig"
+            }
         }
         msr {
             version = "2.9.1"


### PR DESCRIPTION
# Description

- spec.mke.config_data and config_file
- spec.mke.cloud with provider and config_data and config_file

Also

- removed unneeded computed/default values for license_path
- added more schema sanity testing

## Issue

[PRODENG-2320](https://mirantis.jira.com/browse/PRODENG-2320)


[PRODENG-2320]: https://mirantis.jira.com/browse/PRODENG-2320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ